### PR TITLE
For now move some devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,41 +7,40 @@
     "node": "8.*"
   },
   "dependencies": {
+    "@types/express": "^4.16.1",
+    "@types/shelljs": "^0.8.5",
+    "@types/emscripten": "^1.38.0",
+    "@types/node-fetch": "^2.5.2",
+    "@types/google-protobuf": "^3.7.2",
     "@tensorflow/tfjs": "^1.2.11",
     "@tensorflow/tfjs-node": "^1.2.11",
     "express": "^4.16.1",
     "google-protobuf": "^3.10.0",
     "node-fetch": "^2.6.0",
     "node-gles": "0.0.16",
-    "node-wav": "0.0.2"
+    "node-wav": "0.0.2",
+    "shelljs": "^0.8.3",
+    "typescript": "~3.5.3"
   },
   "devDependencies": {
-    "@types/emscripten": "^1.38.0",
-    "@types/express": "^4.16.1",
-    "@types/google-protobuf": "^3.7.2",
-    "@types/node-fetch": "^2.5.2",
-    "@types/shelljs": "^0.8.5",
+    "ts-protoc-gen": "^0.10.0",
     "concurrently": "^4.1.0",
     "nodemon": "^1.19.4",
     "rollup": "^1.24.0",
     "rollup-plugin-commonjs": "^10.0.2",
     "rollup-plugin-node-resolve": "^5.0.0",
     "rollup-plugin-typescript2": "^0.21.1",
-    "shelljs": "^0.8.3",
-    "ts-node": "^8.4.1",
-    "ts-protoc-gen": "^0.10.0",
-    "tslint": "^5.20.0",
-    "typescript": "~3.5.3"
+    "tslint": "^5.20.0"
   },
   "scripts": {
-    "install": "npm run build",
+    "install": "tsc && npm run copy",
     "build": "tsc && rollup -c && npm run copy",
     "start": "node dist/server/index.js",
     "watch:server": "tsc -w",
     "watch:js": "rollup --config rollup.config.js --watch",
     "dev": "concurrently --names \"serverjs,clientjs,server\" -c \"bgBlue.bold,bgMagenta.bold\" npm:watch:server npm:watch:js \"nodemon dist/server/index.js\"",
     "lint": "tslint -p tslint-tsconfig.json -c tslint.json src/**/*.ts",
-    "copy": "ts-node scripts/copy.ts"
+    "copy": "node scripts/copy.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/copy.js
+++ b/scripts/copy.js
@@ -1,5 +1,5 @@
-import * as shell from 'shelljs';
-import * as path from 'path';
+const shell = require('shelljs');
+const path = require('path');
 
 // copy trie_pb.js to dist
 shell.cp(


### PR DESCRIPTION
Since we leverage the `install` to run `tsc` at this moment,
some dependencies need to be moved to `devDependencies`.
Once this module is push to npm repo, we will move these
dependencies back to `devDependencies`.

Signed-off-by: Yihong Wang <yh.wang@ibm.com>